### PR TITLE
always call lua callback when connection goes to STATE_DISCONNECTED

### DIFF
--- a/websocket/src/websocket.cpp
+++ b/websocket/src/websocket.cpp
@@ -195,7 +195,6 @@ static WebsocketConnection* CreateConnection(const char* url)
     conn->m_SSLSocket = 0;
     conn->m_Status = RESULT_OK;
     conn->m_HasHandshakeData = 0;
-    conn->m_WasConnected = 0;
 
 #if defined(HAVE_WSLAY)
     conn->m_Ctx = 0;
@@ -572,10 +571,7 @@ static dmExtension::Result OnUpdate(dmExtension::Params* params)
                 conn->m_BufferSize = 0;
             }
 
-            if (conn->m_WasConnected)
-            {
-                HandleCallback(conn, EVENT_DISCONNECTED, 0, conn->m_BufferSize);
-            }
+            HandleCallback(conn, EVENT_DISCONNECTED, 0, conn->m_BufferSize);
 
             g_Websocket.m_Connections.EraseSwap(i);
             --i;
@@ -682,7 +678,6 @@ static dmExtension::Result OnUpdate(dmExtension::Params* params)
 #endif
             dmSocket::SetBlocking(conn->m_Socket, false);
 
-            conn->m_WasConnected = 1;
             SetState(conn, STATE_CONNECTED);
             HandleCallback(conn, EVENT_CONNECTED, 0, 0);
         }

--- a/websocket/src/websocket.h
+++ b/websocket/src/websocket.h
@@ -100,8 +100,7 @@ namespace dmWebsocket
         Result                          m_Status;
         uint8_t                         m_SSL:1;
         uint8_t                         m_HasHandshakeData:1;
-        uint8_t                         m_WasConnected:1;
-        uint8_t                         :6;
+        uint8_t                         :7;
     };
 
     // Set error message


### PR DESCRIPTION
Currently there is inconsistent behavior in notifying lua side about what happens with connection. If error occurs, after passing state STATE_CONNECTED, lua callback invokes two times(with EVENT_ERROR and EVENT_DISCONNECTED inside). The main problem is there are no way to detect in which state connection was when error occurs, so in there is no clue if callback with EVENT_DISCONNECTED will be invoked after error or not. This PR tries to fix it 