### PR TITLE
Reduced thread name length

### DIFF
--- a/websocket/src/websocket.cpp
+++ b/websocket/src/websocket.cpp
@@ -819,7 +819,7 @@ static dmExtension::Result OnUpdate(dmExtension::Params* params)
             emscripten_websocket_set_onclose_callback(ws, conn, Emscripten_WebSocketOnClose);
             emscripten_websocket_set_onmessage_callback(ws, conn, Emscripten_WebSocketOnMessage);
 #else
-            conn->m_ConnectionThread = dmThread::New((dmThread::ThreadStart)ConnectionWorker, 0x80000, conn, "WebSocketConnectionThread");
+            conn->m_ConnectionThread = dmThread::New((dmThread::ThreadStart)ConnectionWorker, 0x80000, conn, "WSConnect");
 #endif
             SetState(conn, STATE_CONNECTING);
         }


### PR DESCRIPTION
pthread_setname_np() restricts thread name length to 16 characters.

Fixes #38 