### PR TITLE
Added status code to callback when the server closes the connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,7 @@ For command line debugging, there's
 This extension makes use of the C library WSlay by @tatsuhiro-t:
 
 * https://github.com/tatsuhiro-t/wslay
+
+The test server used by the example:
+
+* https://www.lob.com/blog/websocket-org-is-down-here-is-an-alternative

--- a/examples/websocket.gui_script
+++ b/examples/websocket.gui_script
@@ -1,4 +1,4 @@
-local URL = "echo.websocket.org"
+local URL = "echo.websocket.events"
 
 local function click_button(node, action)
 	return gui.is_enabled(node) and action.pressed and gui.pick_node(node, action.x, action.y)
@@ -57,7 +57,7 @@ end
 
 local function websocket_callback(self, conn, data)
 	if data.event == websocket.EVENT_DISCONNECTED then
-		log("Disconnected: " .. tostring(conn))
+		log("Disconnected: " .. tostring(conn) .. " Code: " .. data.code .. " Message: " .. tostring(data.message))
 		self.connection = nil
 		update_gui(self)
 	elseif data.event == websocket.EVENT_CONNECTED then

--- a/websocket/api/api.script_api
+++ b/websocket/api/api.script_api
@@ -61,6 +61,14 @@
             type: string
             desc: The received data if event is `websocket.EVENT_MESSAGE`. Error message otherwise
 
+          - name: handshake_response
+            type: table
+            desc: Handshake response information (status, headers etc)
+
+          - name: code
+            type: number
+            desc: Status code received from the server if the server closed the connection. Only present if event is `EVENT_DISCONNECTED`.
+
 
     returns:
       - name: connection
@@ -86,7 +94,7 @@
               end
 
               function init(self)
-                self.url = "ws://echo.websocket.org"
+                self.url = "ws://echo.websocket.events"
                 local params = {
                   timeout = 3000,
                   headers = "Sec-WebSocket-Protocol: chat\r\nOrigin: mydomain.com\r\n"

--- a/websocket/src/emscripten_callbacks.cpp
+++ b/websocket/src/emscripten_callbacks.cpp
@@ -21,7 +21,8 @@ EM_BOOL Emscripten_WebSocketOnError(int eventType, const EmscriptenWebSocketErro
 EM_BOOL Emscripten_WebSocketOnClose(int eventType, const EmscriptenWebSocketCloseEvent *websocketEvent, void *userData) {
     DebugLog(1, "WebSocket OnClose");
     WebsocketConnection* conn = (WebsocketConnection*)userData;
-    PushMessage(conn, MESSAGE_TYPE_CLOSE, 0, 0);
+    int length = strlen(websocketEvent->reason);
+    PushMessage(conn, MESSAGE_TYPE_CLOSE, length, (uint8_t*)websocketEvent->reason, websocketEvent->code);
     SetState(conn, STATE_DISCONNECTED);
     return EM_TRUE;
 }
@@ -33,7 +34,7 @@ EM_BOOL Emscripten_WebSocketOnMessage(int eventType, const EmscriptenWebSocketMe
     {
         length--;
     }
-    PushMessage(conn, MESSAGE_TYPE_NORMAL, length, websocketEvent->data);
+    PushMessage(conn, MESSAGE_TYPE_NORMAL, length, websocketEvent->data, 0);
     return EM_TRUE;
 }
 

--- a/websocket/src/emscripten_callbacks.cpp
+++ b/websocket/src/emscripten_callbacks.cpp
@@ -23,7 +23,6 @@ EM_BOOL Emscripten_WebSocketOnClose(int eventType, const EmscriptenWebSocketClos
     WebsocketConnection* conn = (WebsocketConnection*)userData;
     int length = strlen(websocketEvent->reason);
     PushMessage(conn, MESSAGE_TYPE_CLOSE, length, (uint8_t*)websocketEvent->reason, websocketEvent->code);
-    SetState(conn, STATE_DISCONNECTED);
     return EM_TRUE;
 }
 EM_BOOL Emscripten_WebSocketOnMessage(int eventType, const EmscriptenWebSocketMessageEvent *websocketEvent, void *userData) {

--- a/websocket/src/websocket.h
+++ b/websocket/src/websocket.h
@@ -80,6 +80,7 @@ namespace dmWebsocket
 
     struct Message
     {
+        uint16_t m_Code;
         uint32_t m_Length:30;
         uint32_t m_Type:2;
     };
@@ -129,6 +130,7 @@ namespace dmWebsocket
         int                             m_BufferSize;
         uint32_t                        m_BufferCapacity;
         Result                          m_Status;
+        uint16_t                        m_CloseCode;
         uint8_t                         m_SSL:1;
         uint8_t                         m_HasHandshakeData:1;
         uint8_t                         :7;
@@ -159,7 +161,7 @@ namespace dmWebsocket
     void HandleCallback(WebsocketConnection* conn, int event, int msg_offset, int msg_length);
 
     // Messages
-    Result PushMessage(WebsocketConnection* conn, MessageType type, int length, const uint8_t* msg);
+    Result PushMessage(WebsocketConnection* conn, MessageType type, int length, const uint8_t* msg, uint16_t code);
 
 #if defined(HAVE_WSLAY)
     // Wslay callbacks

--- a/websocket/src/wslay_callbacks.cpp
+++ b/websocket/src/wslay_callbacks.cpp
@@ -124,7 +124,7 @@ void WSL_OnMsgRecvCallback(wslay_event_context_ptr ctx, const struct wslay_event
     WebsocketConnection* conn = (WebsocketConnection*)user_data;
     if (arg->opcode == WSLAY_TEXT_FRAME || arg->opcode == WSLAY_BINARY_FRAME)
     {
-        PushMessage(conn, MESSAGE_TYPE_NORMAL, arg->msg_length, arg->msg);
+        PushMessage(conn, MESSAGE_TYPE_NORMAL, arg->msg_length, arg->msg, 0);
     } else if (arg->opcode == WSLAY_CONNECTION_CLOSE)
     {
         // The first two bytes is the close code
@@ -137,8 +137,9 @@ void WSL_OnMsgRecvCallback(wslay_event_context_ptr ctx, const struct wslay_event
         }
 
         char buffer[1024];
-        len = dmSnPrintf(buffer, sizeof(buffer), "Server closing (%u). Reason: '%s'", wslay_event_get_status_code_received(ctx), reason);
-        PushMessage(conn, MESSAGE_TYPE_CLOSE, len, (const uint8_t*)buffer);
+        uint16_t status_code = wslay_event_get_status_code_received(ctx);
+        len = dmSnPrintf(buffer, sizeof(buffer), "Server closing (%u). Reason: '%s'", status_code, reason);
+        PushMessage(conn, MESSAGE_TYPE_CLOSE, len, (const uint8_t*)buffer, status_code);
 
         if (!wslay_event_get_close_sent(ctx))
         {


### PR DESCRIPTION
The callback will now include the status code received by the server when the connection was closed.

```
local function websocket_callback(self, conn, data)
	if data.event == websocket.EVENT_DISCONNECTED then
		print(data.code)
		print(data.message)
	end
end
```

Fixes #44 