### PR TITLE
Fix use-after-free: join worker thread before freeing resources

### DIFF
--- a/websocket/src/websocket.cpp
+++ b/websocket/src/websocket.cpp
@@ -435,45 +435,49 @@ static void DestroyConnection(WebsocketConnection* conn)
 {
     {
         DM_MUTEX_SCOPED_LOCK(conn->m_Mutex);
-        conn->m_State = STATE_DISCONNECTED;
-
-#if defined(HAVE_WSLAY)
-        if (conn->m_Ctx)
-            WSL_Exit(conn->m_Ctx);
-#endif
-
-        free((void*)conn->m_CustomHeaders);
-        free((void*)conn->m_Protocol);
-
-        if (conn->m_Callback)
-            dmScript::DestroyCallback(conn->m_Callback);
-
-#if defined(__EMSCRIPTEN__)
-        if (conn->m_WS)
-        {
-            emscripten_websocket_delete(conn->m_WS);
-        }
-#else
-        if (conn->m_Connection)
-            dmConnectionPool::Close(g_Websocket.m_Pool, conn->m_Connection);
-#endif
-
-        if (conn->m_HandshakeResponse)
-            delete conn->m_HandshakeResponse;
-
-        free((void*)conn->m_Buffer);
+        SetState(conn, STATE_DISCONNECTED);
     }
 
+    // Join before freeeing any resources the worker thread may still be accessing
     if (conn->m_ConnectionThread)
     {
         dmThread::Join(conn->m_ConnectionThread);
         conn->m_ConnectionThread = 0;
     }
 
+    if (conn->m_Callback)
+        dmScript::DestroyCallback(conn->m_Callback);
+
+    free((void*)conn->m_CustomHeaders);
+    free((void*)conn->m_Protocol);
+
+    if (conn->m_HandshakeResponse)
+        delete conn->m_HandshakeResponse;
+
+#if defined(__EMSCRIPTEN__)
+    if (conn->m_WS)
+    {
+        emscripten_websocket_delete(conn->m_WS);
+    }
+#else
+    if (conn->m_Connection)
+        dmConnectionPool::Close(g_Websocket.m_Pool, conn->m_Connection);
+#endif
+
+    free((void*)conn->m_Buffer);
+
+#if defined(HAVE_WSLAY)
+    if (conn->m_Ctx)
+    {
+        WSL_Exit(conn->m_Ctx);
+        conn->m_Ctx = 0;
+    }
+#endif
+
     dmMutex::Delete(conn->m_Mutex);
 
-    delete conn;
     DebugLog(dmWebsocket::DEBUG_VERBOSE, "DestroyConnection: %p", conn);
+    delete conn;
 }
 
 

--- a/websocket/src/websocket.cpp
+++ b/websocket/src/websocket.cpp
@@ -445,6 +445,14 @@ static void DestroyConnection(WebsocketConnection* conn)
         conn->m_ConnectionThread = 0;
     }
 
+#if defined(HAVE_WSLAY)
+    if (conn->m_Ctx)
+    {
+        WSL_Exit(conn->m_Ctx);
+        conn->m_Ctx = 0;
+    }
+#endif
+
     free((void*)conn->m_CustomHeaders);
     free((void*)conn->m_Protocol);
 
@@ -465,14 +473,6 @@ static void DestroyConnection(WebsocketConnection* conn)
         delete conn->m_HandshakeResponse;
 
     free((void*)conn->m_Buffer);
-
-#if defined(HAVE_WSLAY)
-    if (conn->m_Ctx)
-    {
-        WSL_Exit(conn->m_Ctx);
-        conn->m_Ctx = 0;
-    }
-#endif
 
     dmMutex::Delete(conn->m_Mutex);
 

--- a/websocket/src/websocket.cpp
+++ b/websocket/src/websocket.cpp
@@ -438,7 +438,7 @@ static void DestroyConnection(WebsocketConnection* conn)
         SetState(conn, STATE_DISCONNECTED);
     }
 
-    // Join before freeeing any resources the worker thread may still be accessing
+    // Join before freeing any resources the worker thread may still be accessing
     if (conn->m_ConnectionThread)
     {
         dmThread::Join(conn->m_ConnectionThread);

--- a/websocket/src/websocket.cpp
+++ b/websocket/src/websocket.cpp
@@ -445,14 +445,11 @@ static void DestroyConnection(WebsocketConnection* conn)
         conn->m_ConnectionThread = 0;
     }
 
-    if (conn->m_Callback)
-        dmScript::DestroyCallback(conn->m_Callback);
-
     free((void*)conn->m_CustomHeaders);
     free((void*)conn->m_Protocol);
 
-    if (conn->m_HandshakeResponse)
-        delete conn->m_HandshakeResponse;
+    if (conn->m_Callback)
+        dmScript::DestroyCallback(conn->m_Callback);
 
 #if defined(__EMSCRIPTEN__)
     if (conn->m_WS)
@@ -463,6 +460,9 @@ static void DestroyConnection(WebsocketConnection* conn)
     if (conn->m_Connection)
         dmConnectionPool::Close(g_Websocket.m_Pool, conn->m_Connection);
 #endif
+
+    if (conn->m_HandshakeResponse)
+        delete conn->m_HandshakeResponse;
 
     free((void*)conn->m_Buffer);
 

--- a/websocket/src/wslay_callbacks.cpp
+++ b/websocket/src/wslay_callbacks.cpp
@@ -59,7 +59,7 @@ int WSL_Poll(wslay_event_context_ptr ctx)
 {
     int r = 0;
     if ((r = wslay_event_recv(ctx)) != 0 || (r = wslay_event_send(ctx)) != 0) {
-        dmLogError("Websocket poll error: %s", WSL_ResultToString(r));
+        dmLogInfo("Websocket poll error: %s", WSL_ResultToString(r)); // expected during intentional disconnect
     }
     return r;
 }


### PR DESCRIPTION
- Fix use-after-free: join worker thread before freeing connection resources
- minor logging refinement

## Summary

| | Crash A | Crash B | Crash C |
|---|---|---|---|
| **Signal** | `EXC_BAD_ACCESS` (code 1) | `EXC_BAD_ACCESS` (code 1) | `EXC_BAD_ACCESS` (code 1) |
| **Bad pointer** | `0x8` | `0x8` | `0xe00000000000014c` |
| **Mechanism** | mach | mach | mach |
| **Defold version** | 1.12.4 | 1.12.4 | 1.12.4 |

---

## Crash A

**Signal:** `EXC_BAD_ACCESS` — attempted to dereference garbage pointer `0x8`

**Stack trace:**
```
_pthread_start
dmThread::ThreadStartProxy          (thread_posix.cpp:40)
dmWebsocket::ConnectionWorker       (websocket.cpp:372)
dmWebsocket::WSL_Poll               (wslay_callbacks.cpp:61)
wslay_event_send                    (wslay_event.c:852)
wslay_frame_send                    (wslay_frame.c:151)
dmWebsocket::WSL_SendCallback       (wslay_callbacks.cpp:107)
dmWebsocket::Send                   (socket.cpp:25)
dmSSLSocket::Send                   (sslsocket.cpp:446)
mbedtls_ssl_session_reset           (ssl_tls.c:8387)
ssl_session_reset_int               (ssl_tls.c:8275)   ← crash
```

**Device context:** iPhone (high-end), iOS 26.5

---

## Crash B

**Signal:** `EXC_BAD_ACCESS` — attempted to dereference garbage pointer `0x8`

**Stack trace:**
```
_pthread_start
dmThread::ThreadStartProxy          (thread_posix.cpp:40)
dmWebsocket::ConnectionWorker       (websocket.cpp:372)
dmWebsocket::WSL_Poll               (wslay_callbacks.cpp:61)
wslay_event_recv                    (wslay_event.c:572)
wslay_frame_recv                    (wslay_frame.c:226)
wslay_recv                          (wslay_frame.c:206)
dmWebsocket::WSL_RecvCallback       (wslay_callbacks.cpp:84)
dmWebsocket::Receive                (socket.cpp:54)
dmSSLSocket::Receive                (sslsocket.cpp:470)
mbedtls_ssl_session_reset           (ssl_tls.c:8387)
ssl_session_reset_int               (ssl_tls.c:8275)   ← crash
```

**Device context:** iPad, iPadOS 16.7.15 (low-memory device, ~2 GB RAM, ~38 MB free at crash time)

---

## Crash C

**Signal:** `EXC_BAD_ACCESS` — attempted to dereference garbage pointer `0xe00000000000014c`

**Stack trace:**
```
_pthread_start
dmThread::ThreadStartProxy          (thread_posix.cpp:40)
dmWebsocket::ConnectionWorker       (websocket.cpp:372)
dmWebsocket::WSL_Poll               (wslay_callbacks.cpp:61)
wslay_event_recv                    (wslay_event.c:572)
wslay_frame_recv                    (wslay_frame.c:310)
wslay_recv                          (wslay_frame.c:206)
dmWebsocket::WSL_RecvCallback       (wslay_callbacks.cpp:84)
dmWebsocket::Receive                (socket.cpp:54)
dmSSLSocket::Receive                (sslsocket.cpp:456)
mbedtls_ssl_read                    (ssl_tls.c:9738)   ← crash
```

**Device context:** iPad, iPadOS 15.8.8 (older device, ~2 GB RAM)

---